### PR TITLE
Proposal -- Responsive props -- add test case of responsive prop

### DIFF
--- a/test/Layout.test.tsx
+++ b/test/Layout.test.tsx
@@ -112,4 +112,30 @@ describe('Layout Base Component', () => {
       width: '30px',
     });
   });
+
+  it('should have responsive padding', () => {
+    const { getByTestId } = renderWithTheme({
+      theme,
+      children: (
+        <Column
+          data-testid="column"
+          reverse
+          px={{
+            s: 10,
+            m: 20,
+            l: 30,
+          }}
+          size={30}
+        />
+      ),
+    });
+
+    const component = getByTestId(/column/i);
+
+    expect(component).toHaveStyle({
+      flexDirection: 'column-reverse',
+      display: 'flex',
+      width: '30px',
+    });
+  });
 });


### PR DESCRIPTION
I've been thinking about what a responsive turbo-props would look like. This is the initial thought. Basically, just an object that would have pre-definedbreakpoints that turbo can query off of.


Curious what your thoughts are.


This is just to show you what I'm thinking. This test will fail. If it's a good idea I can build a lil POC, move and move this diff to the end of the stack where It'll pass when the feature is implemented.



